### PR TITLE
basePathを削除

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-    basePath: '/nextjs',
     output: 'export',
     trailingSlash: true,
 };


### PR DESCRIPTION
## 概要
ブラウザのコンソールを見たところ読み込んでるファイルのパスが間違っていたためbasePathをやめてみる